### PR TITLE
Update `Proto-Plus` to version `1.19.9`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - setuptools
   run:
     - protobuf >=3.12.0
-    - python
+    - python >=3.6
 
 test:
   imports:
@@ -33,6 +33,7 @@ test:
     - pip check
   requires:
     - pip
+    - python <3.10
 
 about:
   home: https://github.com/googleapis/proto-plus-python.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "proto-plus" %}
-{% set version = "1.19.0" %}
+{% set version = "1.19.9" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/proto-plus-{{ version }}.tar.gz
-  sha256: ce6695ce804383ad6f392c4bb1874c323896290a1f656560de36416ba832d91e
+  sha256: 4ca4055f7c5c1a2239ac7a12770a76a16269f58d3f01631523c20fc81dbb14a7
 
 build:
   number: 0


### PR DESCRIPTION

  `proto-plus` version `1.19.9`
1. - [x] check the upstream

https://github.com/googleapis/proto-plus-python/tree/v1.19.9

2. - [x] check the pinnings

https://github.com/googleapis/proto-plus-python/blob/v1.19.9/setup.py

minimal supported version of `python` is `3.6`
https://github.com/googleapis/proto-plus-python/blob/v1.19.9/setup.py#L41

https://github.com/googleapis/proto-plus-python/blob/v1.19.9/noxfile.py

3. - [x] check the changelogs

https://github.com/googleapis/proto-plus-python/blob/v1.19.9/CHANGELOG.md

- The changes mentiones were mainly bug fixes

4. - [x] additional research

    https://github.com/conda-forge/proto-plus-feedstock/issues

    - There are no open issues mentioned at the time of the review on `conda-forge`

5. - [x] verify dev_url

    https://github.com/googleapis/proto-plus-python

6. - [x] verify doc_url

    https://proto-plus-python.readthedocs.io/en/latest/

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
         - the build number is set to zero
10. - [x] verify setuptools
         - `setuptools` is in the recipe
11. - [x] verify wheel
         - `wheel` is in the recipe
12. - [x] pip in the test section
         - `pip` is in the test section
13. - [x] veriy the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `proto-plus` to version `1.19.9`