### PR TITLE
proto-plus 1.26.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
   run:
     - python
     - protobuf >=3.19.0,<6.0.0
+  run_constrained:
+    - google-api-core >=1.31.5
 
 test:
   source_files:
@@ -36,8 +38,8 @@ test:
   requires:
     - pip
     - pytest
-    - google-api-core >=1.31.5
     - pytz
+    - google-api-core >=1.31.5
 
 about:
   home: https://github.com/googleapis/proto-plus-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "proto-plus" %}
-{% set version = "1.24.0" %}
-{% set sha256 = "30b72a5ecafe4406b0d339db35b56c4059064e69227b8c3bda7462397f966445" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/proto-plus-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 6e93d5f5ca267b54300880fff156b6a3386b3fa3f43b1da62e680fc0c586ef22
 
 build:
   number: 0
@@ -23,16 +22,22 @@ requirements:
     - setuptools
   run:
     - python
-    - protobuf >=3.19.0,<6.0.0dev
+    - protobuf >=3.19.0,<6.0.0
 
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
   imports:
     - proto
     - proto.marshal
   commands:
     - pip check
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
+    - google-api-core >=1.31.5
+    - pytz
 
 about:
   home: https://github.com/googleapis/proto-plus-python


### PR DESCRIPTION
proto-plus 1.26.0 

**Destination channel:** Defaults

### Links

- [PKG-7166]
- dev_url:        https://github.com/googleapis/proto-plus-python/tree/v1.26.0
- conda_forge:    https://github.com/conda-forge/proto-plus-feedstock
- pypi:           https://pypi.org/project/proto-plus/1.26.0
- pypi inspector: https://inspector.pypi.io/project/proto-plus/1.26.0

### Explanation of changes:

- new version number


[PKG-7166]: https://anaconda.atlassian.net/browse/PKG-7166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ