### PR TITLE
v1.26.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "proto-plus" %}
-{% set version = "1.26.0" %}
+{% set version = "1.26.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: 6e93d5f5ca267b54300880fff156b6a3386b3fa3f43b1da62e680fc0c586ef22
+  sha256: 21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - protobuf >=3.19.0,<6.0.0
+    - protobuf >=3.19.0,<7.0.0
   run_constrained:
     - google-api-core >=1.31.5
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   dev_url: https://github.com/googleapis/proto-plus-python
-  doc_url: https://proto-plus-python.readthedocs.io
+  doc_url: https://googleapis.dev/python/proto-plus/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
proto-plus v1.26.1
**Destination channel:** defaults

### Links

- [PKG-7497](https://anaconda.atlassian.net/browse/PKG-7497) 
- [Upstream repository](https://github.com/googleapis/proto-plus-python/tree/v1.26.1)



[PKG-7497]: https://anaconda.atlassian.net/browse/PKG-7497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ